### PR TITLE
make txhash argument, clean up code, add calldata forwarding to boostrap code

### DIFF
--- a/evmlab/compiler.py
+++ b/evmlab/compiler.py
@@ -185,15 +185,10 @@ class Program():
 		self._addOp(PUSH1+(length-1), bytecode(value));
 		return self
 
-	def call(self,gas ,address,value = 0,instart = 0, insize = 0, incode = "", out = 0, outsize = 0):
-                if (len(incode)):
-                    self.push(0)
-                    self.push(0)
-                    self.push(len(incode)/2)
-                    self._addOp(CALLDATACOPY)
+	def call(self,gas ,address,value = 0,instart = 0, insize = 0, out = 0, outsize = 0):
 		self.push(outsize)
 		self.push(out)
-		self.push(len(incode)/2)
+		self.push(insize)
 		self.push(instart)
 		self.push(value)
 		self.push(address)

--- a/evmlab/compiler.py
+++ b/evmlab/compiler.py
@@ -185,10 +185,15 @@ class Program():
 		self._addOp(PUSH1+(length-1), bytecode(value));
 		return self
 
-	def call(self,gas ,address,value = 0,instart = 0, insize = 0, out = 0, outsize = 0):
+	def call(self,gas ,address,value = 0,instart = 0, insize = 0, incode = "", out = 0, outsize = 0):
+                if (len(incode)):
+                    self.push(0)
+                    self.push(0)
+                    self.push(len(incode)/2)
+                    self._addOp(CALLDATACOPY)
 		self.push(outsize)
 		self.push(out)
-		self.push(insize)
+		self.push(len(incode)/2)
 		self.push(instart)
 		self.push(value)
 		self.push(address)

--- a/reproduce.py
+++ b/reproduce.py
@@ -24,8 +24,14 @@ from sys import argv, exit
 
 def generateCall(addr, gas = None, value = 0, incode=""):
     """ Generates a piece of code which calls the supplies address"""
+
     p = c.Program()
-    p.call(gas,addr, value, incode=incode)
+    if (len(incode)):
+        p.push(0)
+        p.push(0)
+        p.push(len(incode) / 2)
+        p._addOp(0x37)
+    p.call(gas, addr, value, insize=len(incode)/2)
     p.op(c.POP)
     return p.bytecode()
 

--- a/reproduce.py
+++ b/reproduce.py
@@ -27,9 +27,9 @@ def generateCall(addr, gas = None, value = 0, incode=""):
 
     p = c.Program()
     if (len(incode)):
-        p.push(0)
-        p.push(0)
         p.push(len(incode) / 2)
+        p.push(0)
+        p.push(0)
         p._addOp(0x37)
     p.call(gas, addr, value, insize=len(incode)/2)
     p.op(c.POP)
@@ -71,6 +71,7 @@ def reproduceTx(txhash, evmbin, api):
 
     s = tx['from']
     r = tx['to']
+    tx['input'] = tx['input'][2:]
 
     #s = tx['sender']
     #r = tx['recipient']
@@ -96,18 +97,11 @@ def reproduceTx(txhash, evmbin, api):
             externalAccounts = findExternalCalls(output)
             print("Externals: %s " % externalAccounts )
             toAdd = externalAccounts
-
-    #Now save a trace
-    output =  vm.execute(code = bootstrap, genesis = g_path, json = True, input = tx['input'])
-
-    fd, temp_path = tempfile.mkstemp(dir='.', prefix=txhash+'_', suffix=".txt")
-    with open(temp_path, 'w') as f :
-        f.write("\n".join(output))
-
-    os.close(fd)
-
-
-    print("Saved trace to %s" % temp_path)
+            fd, temp_path = tempfile.mkstemp(dir='.', prefix=txhash+'_', suffix=".txt")
+            with open(temp_path, 'w') as f :
+                f.write("\n".join(output))
+            os.close(fd)
+            print("Saved trace to %s" % temp_path)
     print("Genesis complete: %s" % g_path)
 
 


### PR DESCRIPTION
Run with 

```
./reproduce.py 0x9dbf0326a03a2a3719c27be4fa69aacc9857fd231a8d9dcaede4bb083def75ec
```

To test attack transaction and generate trace. Trace files are not saved inside working directory.