### PR TITLE
use --rm flag to clean up docker containers after exit

### DIFF
--- a/evmlab/gethvm.py
+++ b/evmlab/gethvm.py
@@ -19,7 +19,7 @@ class VM(object):
         value = None, dontExecuteButReturnCommand = False):
 
         if self.docker: 
-            cmd = ['docker', 'run']
+            cmd = ['docker', 'run', '--rm']
             # If any files are referenced, they need to be mounted
             if genesis is not None:
                 cmd.append('-v')

--- a/evmlab/parityvm.py
+++ b/evmlab/parityvm.py
@@ -32,7 +32,7 @@ class VM(object):
         dontExecuteButReturnCommand = False):
 
         if self.docker: 
-            cmd = ['docker', 'run']
+            cmd = ['docker', 'run', '--rm']
             # If any files are referenced, they need to be mounted
             if genesis is not None:
                 cmd.append('-v')


### PR DESCRIPTION
Docker containers persist after exiting, so they accumulate and take up disk space unless cleaned up.