### PR TITLE
compare state roots at end of trace

### DIFF
--- a/containers/pyethereum/run_statetest.py
+++ b/containers/pyethereum/run_statetest.py
@@ -51,6 +51,8 @@ def compute_state_test_unit(state, txdata, konfig):
         #"indexes": indices,
         #"diff": mk_state_diff(prev, post)
     }
+    stateRoot = encode_hex(state.trie.root_hash)
+    print("{{\"stateRoot\": \"{}\"}}".format(stateRoot))
     state.revert(s)
     return output_decl
 

--- a/statetests.ini
+++ b/statetests.ini
@@ -1,22 +1,24 @@
 [DEFAULT]
 
-fork_config = Homestead
+fork_config = Byzantium
 clients = CPP,GETH,PAR,PY
 
 tests_path = /ethereum/tests
+random_tests = No
 prestate_tmp_file = prestate.json
 single_test_tmp_file = single_test_tmp.json
 logs_path = tracerLogs
 
 docker_repo= cdetrio
 pyeth_docker_name = %(docker_repo)s/pyethereum
-cpp_docker_name   = %(docker_repo)s/cpp-ethereum
-parity_docker_name= %(docker_repo)s/parity
-geth_docker_name  = %(docker_repo)s/geth
+cpp_docker_name   = %(docker_repo)s/std-cpp-ethereum
+parity_docker_name= %(docker_repo)s/std-parity
+geth_docker_name  = %(docker_repo)s/std-geth
 
 testeth_docker_name = holiman/testeth
 
 [martin]
+
 
 clients = GETH,PAR,PY,CPP
 #,PAR,PY
@@ -26,6 +28,6 @@ cpp_docker_name   = %(docker_repo)s/testeth
 parity_docker_name= %(docker_repo)s/std-parityvm
 geth_docker_name  = %(docker_repo)s/std-gethvm
 tests_path=/data/workspace/tests
-
+random_tests = Yes
 
 

--- a/trace_statetests.py
+++ b/trace_statetests.py
@@ -38,6 +38,7 @@ def parse_config():
     if uname not in config.sections():
         uname = "DEFAULT"
 
+    cfg['RANDOM_TESTS'] = config[uname]['random_tests']
     cfg['DO_CLIENTS']  = config[uname]['clients'].split(",")
     cfg['FORK_CONFIG'] = config[uname]['fork_config']
     cfg['TESTS_PATH']  = config[uname]['tests_path']
@@ -275,8 +276,10 @@ def startCpp(test_subfolder, test_name, test_dgv):
 
     return VMUtils.startProc(cmd)
 
-def startGeth(test_case, test_tx):
+#def startGeth(test_case, test_tx):
+def startGeth(test_file):
     logger.info("running state test in geth.")
+    """
     genesis = gen.Genesis()
     for account_key in test_case['pre']:
         account = test_case['pre'][account_key]
@@ -299,7 +302,7 @@ def startGeth(test_case, test_tx):
         # OS X workaround for https://github.com/docker/for-mac/issues/1298 "The path /var/folders/wb/d8qys65575g8m2691vvglpmm0000gn/T/tmpctxz3buh.json is not shared from OS X and is not known to Docker." 
         g_path = "/private" + g_path
     input_data = VMUtils.strip_0x(test_tx['data'])
-    
+
     tx_to = test_tx['to']
     tx_value = parse_int_or_hex(test_tx['value'])
     gas_limit = parse_int_or_hex(test_tx['gasLimit'])
@@ -318,7 +321,7 @@ def startGeth(test_case, test_tx):
         logger.info("Insufficient balance. not calling geth")
 
         return None
-    
+
 
     intrinsic_gas = getIntrinsicGas(test_tx)
     if tx_to == "":
@@ -329,20 +332,27 @@ def startGeth(test_case, test_tx):
         logger.info("Insufficient startgas. not calling geth")
 
         return None
-    
+
     if tx_to == "" and input_data == "":
         logger.warn("No init code")
         return None
-    
+
     if tx_to in test_case['pre']:
         if 'code' in test_case['pre'][tx_to]:
             if test_case['pre'][tx_to]['code'] == '':
                 logger.warn("To account in prestate has no code")
                 #return None
-    
-    vm = VMUtils.GethVM(executable = cfg['GETH_DOCKER_NAME'], docker = True)
 
-    return vm.start(genesis = g_path, gas = gas_limit, price = gas_price, json = True, sender = sender, receiver = tx_to, input = input_data, value = tx_value)
+    #vm = VMUtils.GethVM(executable = cfg['GETH_DOCKER_NAME'], docker = True)
+    #return vm.start(genesis = g_path, gas = gas_limit, price = gas_price, json = True, sender = sender, receiver = tx_to, input = input_data, value = tx_value)
+    """
+    testfile_path = os.path.abspath(test_file)
+    mount_testfile = testfile_path + ":" + "/mounted_testfile"
+
+    geth_docker_cmd = ["docker", "run", "--rm", "-t", "-v", mount_testfile, cfg['GETH_DOCKER_NAME'], "--json", "--nomemory", "statetest", "/mounted_testfile"]
+    logger.info(" ".join(geth_docker_cmd))
+
+    return VMUtils.startProc(geth_docker_cmd)
 
 
 
@@ -395,7 +405,8 @@ def startClient(client, single_test_tmp_file, prestate_tmp_file, tx, test_subfol
     Invoke the end_function with the process as arg to stop the process and read output
     """
     if client == 'GETH':
-        return (startGeth(test_case, tx), finishGeth)
+        #return (startGeth(test_case, tx), finishGeth)
+        return (startGeth(single_test_tmp_file), finishGeth)
     if client == 'CPP':
         return (startCpp(test_subfolder, test_name, tx_dgv), finishCpp)
     if client == 'PY':
@@ -479,6 +490,14 @@ regex_skip = [skip.replace('*', '') for skip in SKIP_LIST if '*' in skip]
 START_I = 0
 
 
+def testIterator():
+    if cfg['RANDOM_TESTS'] == 'Yes':
+        logger.info("generating random tests...")
+        return generateTests()
+    else:
+        logger.info("iterating over state tests...")
+        return iterate_tests(ignore=['stMemoryTest','stMemoryTest','stMemoryTest'])
+
 
 def main():
     fail_count = 0
@@ -486,7 +505,8 @@ def main():
     failing_files = []
     test_number = 0
 #    for f in iterate_tests(ignore=['stMemoryTest','stMemoryTest','stMemoryTest']):
-    for f in generateTests():
+#    for f in generateTests():
+    for f in testIterator():
         with open(f) as json_data:
             general_test = json.load(json_data)
             test_name = list(general_test.keys())[0]
@@ -563,6 +583,10 @@ def perform_test(f, test_name, test_number = 0):
         if test_number < START_I and not TEST_WHITELIST:
             continue
 
+        single_statetest = selectSingleFromGeneral(tx_i, f, fork_name)
+        with open(test_tmpfile, 'w') as outfile:
+            json.dump(single_statetest, outfile)
+
         # set up logging to file
         log_filename =  os.path.abspath(cfg['LOGS_PATH'] + '/' + test_name + '.log')
         file_log = setupLogToFile(log_filename)
@@ -579,16 +603,13 @@ def perform_test(f, test_name, test_number = 0):
         for client_name in clients:
  
             if client_name == 'GETH':
-                procs.append( (startGeth(test_case, tx), finishGeth) ) 
+                #procs.append( (startGeth(test_case, tx), finishGeth) )
+                procs.append( (startGeth(test_tmpfile), finishGeth) )
             if client_name == 'CPP':
                 procs.append( (startCpp(test_subfolder, test_name, tx_dgv), finishCpp) )
             if client_name == 'PY':
                 procs.append( (startPython(prestate_tmpfile, tx), finishPython) )
             if client_name == 'PAR':
-                single_statetest = selectSingleFromGeneral(tx_i, f, fork_name)
-                with open(test_tmpfile, 'w') as outfile:
-                    json.dump(single_statetest, outfile)
-
                 procs.append( (startParity(test_tmpfile), finishParity) )
 
 #            procs.append(startClient(client_name ,test_tmpfile, prestate_tmpfile, tx, test_subfolder, test_name, tx_dgv, test_case))
@@ -599,7 +620,7 @@ def perform_test(f, test_name, test_number = 0):
             if proc is not None:
                 canon_trace = end_fn(proc)
             clients_canon_traces.append(canon_trace)
-            
+
         if VMUtils.compare_traces(clients_canon_traces, clients):
             logger.info("equivalent.")
             pass_count += 1


### PR DESCRIPTION
Fixes an error:

```
2017-09-10 15:51:03,578 - INFO - file: /ethereum/tests/GeneralStateTests/stCallCreateCallCodeTest/createNameRegistratorPerTxsNotEnoughGas.json, test name createNameRegistratorPerTxsNotEnoughGas 
Setting prestate to homestead config
2017-09-10 15:51:03,578 - INFO - prestate: {'env': {'currentCoinbase': '0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba', 'currentDifficulty': '0x20000', 'currentGasLimit': '0x02540be400', 'currentNumber': '0x01', 'currentTimestamp': '0x03e8', 'previousHash': '0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6'}, 'pre': {'0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b': {'balance': '0x0de0b6b3a7640000', 'code': '', 'nonce': '0x00', 'storage': {}}}, 'config': {'metropolisBlock': 2000, 'eip158Block': 2000, 'eip150Block': 2000, 'eip155Block': 2000, 'homesteadBlock': 0}}
2017-09-10 15:51:03,579 - INFO - file: /ethereum/tests/GeneralStateTests/stCallCreateCallCodeTest/createNameRegistratorPerTxsNotEnoughGas.json
2017-09-10 15:51:03,579 - INFO - test_name: createNameRegistratorPerTxsNotEnoughGas. tx_i: 0
2017-09-10 15:51:03,580 - INFO - running state test in cpp-ethereum.
2017-09-10 15:51:03,580 - INFO - cpp_cmd: docker run --rm -t -v /ethereum/tests:/mounted_tests cdetrio/cpp-ethereum -t StateTestsGeneral/stCallCreateCallCodeTest -- --singletest createNameRegistratorPerTxsNotEnoughGas --jsontrace '{ "disableStorage":true }' --singlenet Homestead --all -d 0 -g 0 -v 0 --testpath "/mounted_tests" 
docker run --rm -t -v /ethereum/tests:/mounted_tests cdetrio/cpp-ethereum -t StateTestsGeneral/stCallCreateCallCodeTest -- --singletest createNameRegistratorPerTxsNotEnoughGas --jsontrace '{ "disableStorage":true }' --singlenet Homestead --all -d 0 -g 0 -v 0 --testpath "/mounted_tests"
2017-09-10 15:51:03,583 - INFO - running state test in geth.
2017-09-10 15:51:03,596 - INFO - Insufficient startgas. not calling geth
2017-09-10 15:51:03,599 - INFO - running state test in parity.
2017-09-10 15:51:03,600 - INFO - docker run --rm -t -v /home/ubuntu/cdetrio/evmlab/evmlab-holiman/evmlab/single_test_tmp.json:/mounted_testfile cdetrio/parity --json --statetest /mounted_testfile
docker run --rm -t -v /home/ubuntu/cdetrio/evmlab/evmlab-holiman/evmlab/single_test_tmp.json:/mounted_testfile cdetrio/parity --json --statetest /mounted_testfile
2017-09-10 15:51:03,602 - INFO - running state test in pyeth.
2017-09-10 15:51:03,603 - INFO - docker run --rm -t -v /home/ubuntu/cdetrio/evmlab/evmlab-holiman/evmlab/prestate.json:/mounted_prestate cdetrio/pyethereum run_statetest.py /mounted_prestate "{\"data\": \"0x6001600155601080600c6000396000f3006000355415600957005b60203560003555\", \"gasLimit\": \"0x544d\", \"gasPrice\": \"0x01\", \"nonce\": \"0x00\", \"secretKey\": \"0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8\", \"to\": \"\", \"value\": \"0x0186a0\"}"
docker run --rm -t -v /home/ubuntu/cdetrio/evmlab/evmlab-holiman/evmlab/prestate.json:/mounted_prestate cdetrio/pyethereum run_statetest.py /mounted_prestate "{\"data\": \"0x6001600155601080600c6000396000f3006000355415600957005b60203560003555\", \"gasLimit\": \"0x544d\", \"gasPrice\": \"0x01\", \"nonce\": \"0x00\", \"secretKey\": \"0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8\", \"to\": \"\", \"value\": \"0x0186a0\"}"
2017-09-10 15:51:05,622 - INFO - End of cpp trace, processing...
2017-09-10 15:51:05,623 - INFO - Done processing cpp trace (0 steps), returning in canon format
Traceback (most recent call last):
  File "trace_statetests.py", line 603, in <module>
    main()
  File "trace_statetests.py", line 479, in main
    (test_number, num_fails, num_passes,failures) = perform_test(f, test_name, test_number)
  File "trace_statetests.py", line 558, in perform_test
    canon_trace = end_fn(proc)
  File "trace_statetests.py", line 341, in finishGeth
    return finishProc("geth", process, VMUtils.GethVM.canonicalized)
  File "trace_statetests.py", line 327, in finishProc
    outp = VMUtils.finishProc(process)
  File "/home/ubuntu/cdetrio/evmlab/evmlab-holiman/evmlab/evmlab/vm.py", line 113, in finishProc
    (stdoutdata, stderrdata) = process.communicate(timeout=15)
AttributeError: 'list' object has no attribute 'communicate'
```