### PR TITLE
add sources to opviewer

### DIFF
--- a/evmlab/context.py
+++ b/evmlab/context.py
@@ -1,0 +1,109 @@
+from ethereum.utils import mk_contract_address, encode_hex
+
+
+def buildContexts(ops, api, contracts, txhash):
+    contexts = {}
+
+    tx = api.getTransaction(txhash)
+    to = tx['to']
+    blnum = int(tx['blockNumber'])
+
+    if to == '0x0':
+        to = None
+
+    create = to is None
+
+    # contract deployment
+    # need to generate the contract address in order to fetch the bytecode
+    if to is None:
+        baddr = mk_contract_address(tx['from'], tx['nonce'])
+        to = '0x%s' % encode_hex(baddr).decode()
+
+    for depth, addr in findContextChanges(ops, to).items():
+        acc = api.getAccountInfo(addr, blnum)
+        c = findContractForBytecode(contracts, acc['code'])
+        if not c:
+            print("Couldn't find contract for address {}".format(addr))
+            # print(acc['code'])
+        if c and create and addr == to:
+            c.create = True
+
+        contexts[depth] = Context(addr, c)
+
+    return contexts
+
+
+def findContextChanges(ops, original_context):
+    """ This method searches through an EVM-output and locates any depth changes
+     Returns a dict of <depth>: <address>
+     """
+    contexts = {}
+
+    cur_depth = None
+    prev_depth = None
+    prev_op = None
+    cur_address = original_context
+
+    for o in ops:
+        if not 'depth' in o.keys():
+            # We're done here
+            break
+
+        # Address tracking - what's the context we're executing in
+        cur_depth = o['depth']
+
+        # depth may not always start at 1. testrpc starts at 0
+        # this will set the prev_depth from the first op
+        if not prev_op:
+            prev_depth = cur_depth
+            # TODO this might not work for deploys
+            contexts[cur_depth] = cur_address
+
+        if cur_depth > prev_depth:
+            # Made it into a call-variant
+            # All call-lookalikes are 'gas,address,value' on stack,
+            # so address is second item of prev line
+            #
+            # There's one exception, though; CREATE
+            # With a CREATE, we don't know the address until after the RETURN
+            if prev_op['op'] == 0xf0:
+                cur_address = None
+            elif prev_op['op'] != 0xf4:
+                cur_address = prev_op['stack'][-2]
+                contexts[cur_depth] = cur_address
+
+        if cur_depth < prev_depth:
+            if cur_address is None:
+                print(prev_op)
+                print(o)
+                # TODO set context for cur_depth here. Should be RETURN opcode & get address from that
+            # Returned from a call
+            cur_address = contexts[cur_depth]
+
+        prev_op = o
+        prev_depth = cur_depth
+
+    return contexts
+
+
+def findContractForBytecode(contracts, bytecode):
+    if bytecode.startswith('0x'):
+        bytecode = bytecode[2:]
+
+    for c in contracts:
+        if c.bin == bytecode or c.binRuntime == bytecode:
+            return c
+
+    return None
+
+
+class Context(object):
+    def __init__(self, address, contract):
+        self.address = address
+        self.contract = contract
+
+    def getSourceCode(self, pc):
+        if self.contract:
+            return self.contract.getSourceCode(pc)
+
+        return "Missing Contract"

--- a/evmlab/context.py
+++ b/evmlab/context.py
@@ -56,7 +56,6 @@ def findContextChanges(ops, original_context):
         # this will set the prev_depth from the first op
         if not prev_op:
             prev_depth = cur_depth
-            # TODO this might not work for deploys
             contexts[cur_depth] = cur_address
 
         if cur_depth > prev_depth:
@@ -73,10 +72,10 @@ def findContextChanges(ops, original_context):
                 contexts[cur_depth] = cur_address
 
         if cur_depth < prev_depth:
-            if cur_address is None:
-                print(prev_op)
-                print(o)
-                # TODO set context for cur_depth here. Should be RETURN opcode & get address from that
+            # RETURN op. we now know the prev_depth address, so add to context
+            if cur_address is None and prev_op['op'] == 0xf3:
+                prev_address = o['stack'][-1]
+                contexts[prev_depth] = prev_address
             # Returned from a call
             cur_address = contexts[cur_depth]
 
@@ -106,4 +105,4 @@ class Context(object):
         if self.contract:
             return self.contract.getSourceCode(pc)
 
-        return "Missing Contract"
+        return "Missing Contract", (0, 0)

--- a/evmlab/contract.py
+++ b/evmlab/contract.py
@@ -43,10 +43,10 @@ class Contract():
     insRuntime = None
 
     content = []
-    contractText = ""
 
     def __init__(self, sourcelist, contract=None):
         self.sourcelist = sourcelist
+        self._contractText = None
 
         self._loadSources()
         self._loadContract(contract)
@@ -60,6 +60,13 @@ class Contract():
         self._create = val
         self._loadContractText()
 
+    @property
+    def contractText(self):
+        if self._contractText == None:
+            self._loadContractText()
+
+        return self._contractText
+
     def isInitialized(self):
         return self.bin is not None or self.binRuntime is not None
 
@@ -69,7 +76,7 @@ class Contract():
         try:
             code_mapping = self._getInstructionMapping(pc)
         except KeyError:
-            return "Missing code"
+            return "Missing code", (0,0)
         s = int(s)
         l = int(l)
 
@@ -85,7 +92,7 @@ class Contract():
         try:
             [s, l, f, j] = self._getInstructionMapping(pc)
         except KeyError:
-            return "Missing code"
+            return "Missing code", (0,0)
 
         s = int(s)
         l = int(l)
@@ -160,12 +167,9 @@ class Contract():
         self.mappingRuntime = parseSourceMap(load('srcmap-runtime'))
         self.mapping = parseSourceMap(load('srcmap'))
 
-        if self.isInitialized():
-            self._loadContractText()
-
     def _loadContractText(self):
         [s, l, f, j] = self._getInstructionMapping(0)
 
         f = int(f)
 
-        self.contractText = self.content[f]
+        self._contractText = self.content[f]

--- a/evmlab/contract.py
+++ b/evmlab/contract.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+from evmlab.opcodes import parseCode
+
+"""
+Solidity source code mappings, as 
+documented [here](http://solidity.readthedocs.io/en/develop/miscellaneous.html#source-mappings)
+
+"""
+
+
+def update(original, changes):
+    retval = []
+    for i in range(0, len(original)):
+        val = original[i]
+        if i < len(changes) and len(changes[i]) > 0:
+            val = changes[i]
+        retval.append(val)
+    return retval
+
+
+def parseSourceMap(maptext):
+    mapping = []
+
+    if maptext is None:
+        return mapping
+
+    entries = maptext.split(";")
+    m = ["", "", "", ""]
+    for e in entries:
+        vals = e.split(":")
+        m = update(m, vals)
+        mapping.append(m)
+    return mapping
+
+
+class Contract():
+    bin = None
+    ins = None
+    binRuntime = None
+    insRuntime = None
+    create = False
+    content = []
+
+    def __init__(self, sourcelist, contract=None):
+        self.sourcelist = sourcelist
+
+        def load(key):
+            try:
+                return contract[key]
+            except KeyError:
+                print("Contract JSON missing key: %s" % key)
+                return None
+
+        if contract:
+            self._addBinRuntime(load('bin-runtime'))
+            self.mappingRuntime = parseSourceMap(load('srcmap-runtime'))
+            self._addBin(load('bin'))
+            self.mapping = parseSourceMap(load('srcmap'))
+
+        self._loadSources()
+
+    def isInitialized(self):
+        return self.bin is not None or self.binRuntime is not None
+
+    def getSourceCode(self, pc):
+        i = self._getMappingIndex(pc)
+
+        if i == -1:
+            return "Missing code"
+
+        mapping = self.mapping if self.create else self.mappingRuntime
+
+        [s, l, f, j] = mapping[i]
+        # Where
+        # s is the byte-offset to the start of the range in the source file,
+        # l is the length of the source range in bytes and
+        # f is the source index mentioned above.
+        # j can be either i, o or -
+        #   i   signifying whether a jump instruction goes into a function,
+        #   o   returns from a function or
+        #   -   is a regular jump as part of e.g. a loop.
+
+        s = int(s)
+        l = int(l)
+        f = int(f)
+        text = self.content[f]
+        return text[s:s + l]
+
+    def getSource(self, pc):
+        i = self._getMappingIndex(pc)
+
+        # if pc > len(self.mapping):
+        if i == -1:
+            return ""
+
+        [s, l, f, j] = self.mapping[i]
+        s = int(s)
+        l = int(l)
+        f = int(f)
+        text = self.content[f]
+
+        return (text[:s], text[s:s + l], text[s + l:])
+
+    def _getMappingIndex(self, pc):
+        ins = self.ins if self.create else self.insRuntime
+        pcs = list(ins.keys())
+
+        if pc in pcs:
+            return pcs.index(pc)
+
+        return -1
+
+    def _loadSources(self):
+        for file in self.sourcelist:
+            with open(file) as s:
+                print(s.name)
+                self.content.append(s.read())
+
+    def _addBinRuntime(self, bytecode):
+        self.binRuntime = bytecode
+        self.insRuntime = parseCode(bytecode)
+
+    def _addBin(self, bytecode):
+        self.bin = bytecode
+        self.ins = parseCode(bytecode)

--- a/evmlab/opcodes.py
+++ b/evmlab/opcodes.py
@@ -137,10 +137,6 @@ def parseCode(code):
     code = remove_0x_head(code)
     codes = [c for c in decode_hex(code)]
 
-    # Remove the last 43 bytes, which is the contract metadata
-    # TODO: Make this conditional, as it's assumed the metadata exists.
-    # codes = codes[:-43]
-
     instructions = collections.OrderedDict()
     pc = 0
     length = None

--- a/evmlab/opcodes.py
+++ b/evmlab/opcodes.py
@@ -1,3 +1,6 @@
+from ethereum.utils import decode_hex, remove_0x_head, bytearray_to_bytestr, encode_hex
+from copy import copy
+import collections
 # Taken from https://github.com/ethereum/pyethereum/blob/develop/ethereum/opcodes.py
 # Done this way to reduce dependencies a bit
 # schema: [opcode, ins, outs, gas]
@@ -128,3 +131,36 @@ BALANCE_SUPPLEMENTAL_GAS = 380
 CALL_CHILD_LIMIT_NUM = 63
 CALL_CHILD_LIMIT_DENOM = 64
 SUICIDE_SUPPLEMENTAL_GAS = 5000
+
+
+def parseCode(code):
+    code = remove_0x_head(code)
+    codes = [c for c in decode_hex(code)]
+
+    # Remove the last 43 bytes, which is the contract metadata
+    # TODO: Make this conditional, as it's assumed the metadata exists.
+    # codes = codes[:-43]
+
+    instructions = collections.OrderedDict()
+    pc = 0
+    length = None
+    while pc < len(codes):
+        try:
+            opcode = opcodes[codes[pc]]
+        except KeyError:
+            opcode = ['INVALID', 0, 0, 0]
+        if opcode[0][:4] == 'PUSH':
+            opcode = copy(opcode)
+            length = codes[pc] - 0x5f
+            pushData = codes[pc + 1 : pc + length + 1]
+            pushData = "0x" + encode_hex(bytearray_to_bytestr(pushData)).decode()
+            opcode.append(pushData)
+
+        instructions[pc] = opcode
+
+        if length is not None:
+            pc += length
+            length = None
+        pc += 1
+
+    return instructions

--- a/evmlab/reproduce.py
+++ b/evmlab/reproduce.py
@@ -46,7 +46,8 @@ def findExternalCalls(list_of_output):
 
         if 'opName' in o and o['opName'] in externals.keys():
             accounts.add(externals[o['opName']](o))
-    
+
+    accounts.discard('0x0')
     return accounts
 
 def findStorageLookups(list_of_output, original_context):
@@ -124,6 +125,9 @@ def reproduceTx(txhash, vm, api):
     s = tx['from']
     r = tx['to']
     tx['input'] = tx['input'][2:]
+
+    if r == '0x0':
+        r = None
 
     create = r is None
 

--- a/evmlab/utils.py
+++ b/evmlab/utils.py
@@ -1,0 +1,46 @@
+import os, shutil
+from web3 import Web3, RPCProvider
+from urllib.parse import urlparse
+from . import multiapi, etherchain
+
+def getApi(providerUrl):
+    parsed_web3 = urlparse(providerUrl)
+    if not parsed_web3.hostname:
+        #User probably omitted 'http://'
+        parsed_web3 = urlparse("http://%s" % providerUrl)
+
+    ssl = (parsed_web3.scheme == 'https')
+    port = parsed_web3.port
+
+    if not port:
+        #Not explicitly defined
+        if ssl:
+            port = 443
+        else:
+            port = 80
+    web3 = Web3(RPCProvider(host = parsed_web3.hostname,port= port ,ssl= ssl))
+    api = multiapi.MultiApi(web3 = web3, etherchain = etherchain.EtherChainAPI())
+
+    return api
+
+def saveFiles(destination, artefacts):
+    """
+    Copies the supplied artefacts to the right folder
+
+    TODO: Add option to save files into a zip file for download instead
+    """
+
+    print("Saving files")
+    print("")
+    saved = {}
+
+    for desc, path in artefacts.items():
+        if os.path.isfile(path):
+            fname = os.path.basename(path)
+            shutil.copy(path, destination)
+            saved[desc] = {'path': destination,'name': fname}
+            print("* %s -> %s%s" % (desc, destination, fname) )
+        else:
+            print("Failed to save %s - not a file" % path)
+
+    return saved

--- a/reproducer.py
+++ b/reproducer.py
@@ -234,6 +234,9 @@ def main(args):
         print("\nFor opviewing:\n")
         print("python3 opviewer.py -f %s/%s" % (saved_files['json-trace']['path'],saved_files['json-trace']['name']))
 
+        print("\nFor opviewing with sources:\n")
+        print("python3 opviewer.py -f %s/%s --web3 '%s' -s path_to_contract_dir -j path_to_solc_combined_json %s" % (saved_files['json-trace']['path'],saved_files['json-trace']['name'], args.web3, args.hash))
+
         (zipfilepath, zipfilename) = zipFiles(saved_files, args.hash[:8])
         print("\nZipped files into %s%s" % (zipfilepath, zipfilename))
 


### PR DESCRIPTION
* builds upon PR #31 

This PR adds a window in `opviewer.py` that displays the source code of the current op.

Notable changes:

1. `opviewer.py` - if given a txHash and a `combined.json` file, will display the sourcecode.
2. `opviewer.py` - will now call `reproducer` if a file is not passed in. This is more of a convenience thing. I figured it was easier then running 2 separate cmds & I needed to add `--web3`, `--hash` to the opviewer anyways.
3. `reproducer.py` - remove default `www` value as this caused the webapp to always run if flask was installed

TODO:
- [ ] support `CREATE` opcodes. context is built fine, but the new contract bytecode doesn't match the compiled code.
- [ ] better error handling
- [ ] test different contract imports in `combined.json` file

I have tested on a few different contract transactions & deployments, and it seems to work correctly. 

The window could be better & highlight the current code in the contract. Currently I surround the current code with `**code**`.


