### PR TITLE
improve source code view

### DIFF
--- a/evmlab/context.py
+++ b/evmlab/context.py
@@ -102,7 +102,7 @@ def findContractChanges(ops, original_contract):
         prev_op = o
         prev_depth = cur_depth
 
-    # handle ganache-cli debug_traceTransaction output
+    # handle debug_traceTransaction output
     def fixAddr(a):
         if len(a) > 40:
             if (a.startswith('0x') and len(a) == 42):

--- a/evmlab/context.py
+++ b/evmlab/context.py
@@ -1,8 +1,9 @@
 from ethereum.utils import mk_contract_address, encode_hex
+from .contract import Contract
 
 
 def buildContexts(ops, api, contracts, txhash):
-    contexts = {}
+    contract_stack = []
 
     tx = api.getTransaction(txhash)
     to = tx['to']
@@ -19,44 +20,57 @@ def buildContexts(ops, api, contracts, txhash):
         baddr = mk_contract_address(tx['from'], tx['nonce'])
         to = '0x%s' % encode_hex(baddr).decode()
 
-    for depth, addr in findContextChanges(ops, to).items():
-        acc = api.getAccountInfo(addr, blnum)
-        c = findContractForBytecode(contracts, acc['code'])
+    cache = {}
+    for addr in findContractChanges(ops, to):
+        if addr in cache:
+            c = cache[addr]
+            if c and create and addr == to:
+                # if it's cached, then the contract is already created so we need to create a new Contract instance w/ create = False
+                newc = object.__new__(Contract)
+                newc.__dict__ = c.__dict__.copy() 
+                c = newc
+
+        else:
+            acc = api.getAccountInfo(addr, blnum)
+            c = findContractForBytecode(contracts, acc['code'])
+            cache[addr] = c
         if not c:
             print("Couldn't find contract for address {}".format(addr))
-            # print(acc['code'])
         if c and create and addr == to:
             c.create = True
 
-        contexts[depth] = Context(addr, c)
+        contract_stack.append(Context(addr, c))
 
-    return contexts
+    return contract_stack
 
 
-def findContextChanges(ops, original_context):
+def findContractChanges(ops, original_contract):
     """ This method searches through an EVM-output and locates any depth changes
-     Returns a dict of <depth>: <address>
+     Returns a stack of address that are visited. Each depth change will push another addy on the stack
      """
-    contexts = {}
+    addr_stack = []
 
     cur_depth = None
     prev_depth = None
     prev_op = None
-    cur_address = original_context
+    cur_address = original_contract
+    place_holders = [] # stores the index of where CREATE op addr should go in the addr_stack
+    depth_to_addr = {} # mapping to track depth to an addr so we can easily push the current addr on the stack when we return from a call
 
     for o in ops:
         if not 'depth' in o.keys():
             # We're done here
             break
 
-        # Address tracking - what's the context we're executing in
+        # Address tracking
         cur_depth = o['depth']
 
-        # depth may not always start at 1. testrpc starts at 0
+        # depth may not always start at 1. ganache-cli starts at 0
         # this will set the prev_depth from the first op
         if not prev_op:
             prev_depth = cur_depth
-            contexts[cur_depth] = cur_address
+            addr_stack.append(cur_address)
+            depth_to_addr[cur_depth] = cur_address
 
         if cur_depth > prev_depth:
             # Made it into a call-variant
@@ -65,24 +79,40 @@ def findContextChanges(ops, original_context):
             #
             # There's one exception, though; CREATE
             # With a CREATE, we don't know the address until after the RETURN
+            # so we push a placeholder and update on the Return 
             if prev_op['op'] == 0xf0:
                 cur_address = None
-            elif prev_op['op'] != 0xf4:
+                place_holders.append(len(addr_stack))
+            else:
                 cur_address = prev_op['stack'][-2]
-                contexts[cur_depth] = cur_address
+                depth_to_addr[cur_depth] = cur_address
+
+            addr_stack.append(cur_address)
 
         if cur_depth < prev_depth:
             # RETURN op. we now know the prev_depth address, so add to context
             if cur_address is None and prev_op['op'] == 0xf3:
                 prev_address = o['stack'][-1]
-                contexts[prev_depth] = prev_address
+                i = place_holders.pop()
+                addr_stack[i] = prev_address
             # Returned from a call
-            cur_address = contexts[cur_depth]
+            cur_address = depth_to_addr[cur_depth]
+            addr_stack.append(cur_address)
 
         prev_op = o
         prev_depth = cur_depth
 
-    return contexts
+    # handle ganache-cli debug_traceTransaction output
+    def fixAddr(a):
+        if len(a) > 40:
+            if (a.startswith('0x') and len(a) == 42):
+               return a 
+            else:
+                return "0x%s" % a[24:]
+    
+    addr_stack = [fixAddr(a) for a in addr_stack]
+
+    return addr_stack
 
 
 def findContractForBytecode(contracts, bytecode):

--- a/evmlab/contract.py
+++ b/evmlab/contract.py
@@ -82,13 +82,13 @@ class Contract():
         if f < 0:
             while True:
                 pc -= 1
-                [s, l, f, j] = self._getInstructionMapping(pc)
+                try:
+                    [s, l, f, j] = self._getInstructionMapping(pc)
+                except KeyError:
+                    f = -1
                 f = int(f)
                 if f > 0:
-                    try:
-                        c = self.contractTexts[f]
-                    except KeyError:
-                        return "Missing code", (0,0)
+                    c = self.contractTexts[f]
                     s = int(s)
                     l = int(l)
                     break

--- a/evmlab/contract.py
+++ b/evmlab/contract.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import re
 
 from evmlab.opcodes import parseCode
 
@@ -42,13 +43,10 @@ class Contract():
     binRuntime = None
     insRuntime = None
 
-    content = []
+    def __init__(self, sources, contract=None):
+        self.sources = sources or []
+        self._contractTexts = {}
 
-    def __init__(self, sourcelist, contract=None):
-        self.sourcelist = sourcelist
-        self._contractText = None
-
-        self._loadSources()
         self._loadContract(contract)
 
     @property
@@ -58,58 +56,84 @@ class Contract():
     @create.setter
     def create(self, val):
         self._create = val
-        self._loadContractText()
+        self._loadContractTexts()
 
     @property
-    def contractText(self):
-        if self._contractText == None:
-            self._loadContractText()
+    def contractTexts(self):
+        if len(self._contractTexts.keys()) == 0:
+            self._loadContractTexts()
 
-        return self._contractText
+        return self._contractTexts
 
     def isInitialized(self):
         return self.bin is not None or self.binRuntime is not None
 
     def getSourceCode(self, pc):
-        [s, l, f, j] = self._getInstructionMapping(0)
-
         try:
-            code_mapping = self._getInstructionMapping(pc)
+            [s, l, f, j] = self._getInstructionMapping(pc)
+            f = int(f)
+            c = self.contractTexts[f]
         except KeyError:
             return "Missing code", (0,0)
         s = int(s)
         l = int(l)
 
-        # code_mapping offsets will be in relation to the entire contract file
-        # this could be multiple contracts in a single .sol file, since we are
-        # returning only the contract text, we need to update code_mapping offsets
-        # to match the contractText
-        transformed_mapping = [int(code_mapping[0]) - s, int(code_mapping[1]) - l]
+        # contract is missing, return the last valid ins mapping
+        if f < 0:
+            while True:
+                pc -= 1
+                [s, l, f, j] = self._getInstructionMapping(pc)
+                f = int(f)
+                if f > 0:
+                    try:
+                        c = self.contractTexts[f]
+                    except KeyError:
+                        return "Missing code", (0,0)
+                    s = int(s)
+                    l = int(l)
+                    break
 
-        return self.contractText[s:s + l], transformed_mapping
+        # see if text contains multiple contracts
+        contract_start_indices = [m.start(0)
+                                  for m in re.finditer('contract ', c)]
 
-    def getCode(self, pc):
-        try:
-            [s, l, f, j] = self._getInstructionMapping(pc)
-        except KeyError:
-            return "Missing code", (0,0)
+        # for multi contract files, get the start of the contract for the current instruction
+        if len(contract_start_indices) > 1:
+            contract_start = 0
+            contract_end = -1
 
-        s = int(s)
-        l = int(l)
-        return self.contractText[s:s + l]
+            for i in contract_start_indices:
+                if i == s:
+                    contract_start = s
+                    break
+                elif i > s:
+                    # get the previous index
+                    ci = contract_start_indices.index(i) - 1
+                    if ci >= 0:
+                        contract_start = contract_start_indices[ci]
+                    break
+                elif s > i and i == contract_start_indices[-1]:
+                    contract_start = contract_start_indices[-1]
+            
+            pos = contract_start + c[contract_start:].find('{')
+            openBr = 0
+            while pos < len(c):
+                if c[pos] == '{':
+                    openBr += 1
+                elif c[pos] == '}':
+                    openBr -= 1
+                
+                if openBr == 0:
+                    contract_end = pos + 1
+                    break
 
-    def getSource(self, pc):
-        try:
-            [s, l, f, j] = self._getInstructionMapping(pc)
-        except KeyError:
-            return ""
+                pos += 1
 
-        s = int(s)
-        l = int(l)
-        f = int(f)
-        text = self.content[f]
-
-        return (text[:s], text[s:s + l], text[s + l:])
+            # return only the contract we're interested in
+            # we need to update the bytes start & end pos to reflect the truncated text we are returning
+            return c[contract_start:contract_end], [s - contract_start, l]
+        else:
+            return c, [s, l]
 
     def _getInstructionMapping(self, pc):
         """
@@ -137,12 +161,6 @@ class Contract():
 
         raise KeyError
 
-    def _loadSources(self):
-        for file in self.sourcelist:
-            with open(file) as s:
-                print(s.name)
-                self.content.append(s.read())
-
     def _loadContract(self, contract):
         if not contract:
             return
@@ -159,6 +177,7 @@ class Contract():
             self.binRuntime = bytecode
             self.insRuntime = parseCode(bytecode)
 
+
         bytecode = load('bin')
         if bytecode:
             self.bin = bytecode
@@ -167,9 +186,13 @@ class Contract():
         self.mappingRuntime = parseSourceMap(load('srcmap-runtime'))
         self.mapping = parseSourceMap(load('srcmap'))
 
-    def _loadContractText(self):
-        [s, l, f, j] = self._getInstructionMapping(0)
+    def _loadContractTexts(self):
+        mapping = self.mapping if self.create else self.mappingRuntime
 
-        f = int(f)
+        contract_indexes = set()
+        for [s, l, f, j] in mapping:
+            f = int(f)
+            contract_indexes.add(f)
 
-        self._contractText = self.content[f]
+        for i in contract_indexes:
+            self._contractTexts[i] = self.sources[f]

--- a/evmlab/opcodes.py
+++ b/evmlab/opcodes.py
@@ -134,8 +134,13 @@ SUICIDE_SUPPLEMENTAL_GAS = 5000
 
 
 def parseCode(code):
-    code = remove_0x_head(code)
-    codes = [c for c in decode_hex(code)]
+    code = code[2:] if code[:2] == '0x' else code
+
+    try:
+        codes = [c for c in decode_hex(code)]
+    except ValueError as e:
+        print(code)
+        raise Exception("Did you forget to link any libraries?") from e
 
     instructions = collections.OrderedDict()
     pc = 0
@@ -149,7 +154,9 @@ def parseCode(code):
             opcode = copy(opcode)
             length = codes[pc] - 0x5f
             pushData = codes[pc + 1 : pc + length + 1]
-            pushData = "0x" + encode_hex(bytearray_to_bytestr(pushData)).decode()
+            pushData = "0x" + encode_hex(bytearray_to_bytestr(pushData))
+            if type(pushData) is not str:
+                pushData = pushData.decode()
             opcode.append(pushData)
 
         instructions[pc] = opcode

--- a/opviewer.py
+++ b/opviewer.py
@@ -384,7 +384,26 @@ def opSource(c, opcode, srcptr, track=True, length=12):
                 srcptr = max(len(split) - length, 0)
             view = split[srcptr: srcptr + length]
 
-        return srcptr, "\n".join(view)
+        viewtxt = "\n".join(view)
+        viewtxt_split = viewtxt.split('**')
+
+        if len(viewtxt_split) == 1:
+            # entire view is the current code
+            viewtxt = viewtxt_split
+            viewtxt_split[0] = ('source', viewtxt_split[0])
+        elif len(viewtxt_split) == 2:
+            # part of the view is the current code
+            viewtxt = viewtxt_split
+            if viewtxt[0].strip() == '':
+                viewtxt_split[1] = ('source', viewtxt_split[1])
+            else:
+                viewtxt_split[0] = ('source', viewtxt_split[0])
+        elif len(viewtxt_split) == 3:
+            # current code is a slice of the view
+            viewtxt = viewtxt_split
+            viewtxt_split[1] = ('source', viewtxt_split[1])
+
+        return srcptr, viewtxt
     else:
         return srcptr, ""
 
@@ -432,6 +451,7 @@ class DebugViewer():
             ('body_text', 'dark cyan', 'light gray'),
             ('buttons', 'yellow', 'dark green', 'standout'),
             ('section_text', 'body_text'), # alias to body_text
+            ('source', 'white', 'black', 'bold'), # bold text in monochrome mode
             ]
 
         self.ops_view = ops_view

--- a/opviewer.py
+++ b/opviewer.py
@@ -5,6 +5,7 @@ from evmlab.context import buildContexts
 from evmlab.contract import Contract
 from evmlab import reproduce, utils
 from evmlab import vm as VMUtils
+from evmlab.opcodes import opcodes
 
 # Python3 support
 try:
@@ -232,7 +233,7 @@ def stackdump(st, length = 16, minrows=8, start =0, opcode = None):
 
     return '\n'.join(result)
 
-def opDump(obj):
+def opDump(obj, addr):
     """
     @brief returns information about current exeution step
     """
@@ -265,6 +266,7 @@ def opDump(obj):
     result.append(attr('gas'))
     result.append(attr('memSize'))
     result.append(attr('depth'))
+    result.append([('bold',"{:10}: ".format("addr")), addr])
 
     return result
 
@@ -304,6 +306,15 @@ def toText(op):
         return " ".join(result)
 
     result.append(attr('pc', '{:>5d}'))
+
+    # support ganache-cli debug_traceTransaction
+    if ('op' in op and 'opName' not in op):
+        op['opName'] = op['op']
+        for k,v in opcodes.items():
+            if v[0] == op['op']:
+                op['op'] = k
+                break
+
     result.append(attr('opName','{:>12}', False))
     result.append(attr('op', '{:>5x}'))
     result.append(attr('gas', '{:>8x}'))
@@ -390,6 +401,8 @@ class DebugViewer():
         self.opptr = 0
         self.srcptr = 0
         self.srctrack = True
+        self.forward = True
+        self.step = 1
 
         self.ops_view = None
         self.mem_view = None
@@ -399,9 +412,10 @@ class DebugViewer():
         self.help_view = None
 
 
-    def setTrace(self, trace, contexts):
+    def setTrace(self, trace, contract_stack):
         self.operations = trace
-        self.contexts = contexts
+        self.contract_stack = contract_stack
+        self.cptr = 0
 
         ops_view   = urwid.Text(self.getOp())
         mem_view   = urwid.Text(self.getMem())
@@ -473,17 +487,21 @@ class DebugViewer():
             return op
         if key not in op.keys():
             return default
-        if op[key]:
+        if op[key] is not None:
             return op[key]
         return default
 
 
     def getOp(self):
-        return opDump(self._op(default={'pc':1}))
+        return opDump(self._op(default={'pc':1}), self.contract_stack[self.cptr].address)
 
     def getMem(self):
         m = self._op('memory',"0x")
+        if type(m) is list:
+            m = "0x%s" % "".join(m)
         prev_m = self._prevop('memory',"0x")
+        if type(prev_m) is list:
+            prev_m = "0x%s" % "".join(prev_m)
         return hexdump(m[2:], start = self.memptr, prevsrc = prev_m[2:])
 
     def getStack(self):
@@ -507,24 +525,29 @@ class DebugViewer():
     def getSource(self, track=None):
         op = self.operations[self.opptr]
 
-        if not self.contexts:
+        if len(self.contract_stack) == 0:
             return "No Source Provided"
 
         if 'depth' not in op:
             return ""
 
-        prev_d = self._prevop('depth', None)
+        prev_op = self.operations[self.opptr - self.step] if self.forward else self.operations[self.opptr + self.step]
+        prev_d = prev_op['depth'] if 'depth' in prev_op else None
 
-        if prev_d and prev_d != op['depth']:
+        if prev_d is not None and prev_d != op['depth']:
             self.srcptr = 0
+            if self.forward:
+                self.cptr += 1
+            else:
+                 self.cptr -= 1
 
-        c = self.contexts[op['depth']]
-        # print(self.srcptr)
+        if not self.contract_stack[self.cptr]:
+            return "Missing context"
 
         if track is None:
             track = self.srctrack
 
-        self.srcptr, txt = opSource(c, op, self.srcptr, track=track)
+        self.srcptr, txt = opSource(self.contract_stack[self.cptr], op, self.srcptr, track=track)
         return txt
 
     def getHelp(self):
@@ -534,9 +557,9 @@ class DebugViewer():
     press `q` to quit
         """
     def _refresh(self):
+        self.source_view.set_text(self.getSource()) # needs to occur before getOp to print correct addr
         self.ops_view.set_text(self.getOp())
         self.trace_view.set_text(self.getTrace())
-        self.source_view.set_text(self.getSource())
         self.mem_view.set_text(self.getMem())
         self.stack_view.set_text(self.getStack())
 
@@ -551,48 +574,50 @@ class DebugViewer():
         if key in ('q', 'Q'):
             raise urwid.ExitMainLoop()
 
-        step = 1
+        self.step = 1
         if key in ('A','Z','S','X','D','C','F','V'):
-            step = 10
+            self.step = 10
 
         # UP trace
         if key in ('a','A'):
-            self.opptr = max(0, self.opptr-step)
+            self.opptr = max(0, self.opptr-self.step)
+            self.forward = False
             self._refresh()
 
         # DOWN trace
         if key in ('z','Z'):
-            self.opptr = min(self.opptr+step, len(self.operations)-1)
+            self.opptr = min(self.opptr+self.step, len(self.operations)-1)
+            self.forward = True
             self._refresh()
 
         # UP mem
         if key in ('s','S'):
-            self.memptr = max(0, self.memptr-step)
+            self.memptr = max(0, self.memptr-self.step)
             self.mem_view.set_text(self.getMem())
 
         # DOWN mem
         if key in ('x','X'):
-            self.memptr = self.memptr+step
+            self.memptr = self.memptr+self.step
             self.mem_view.set_text(self.getMem())
 
         # UP stack
         if key in ('d','D'):
-            self.stackptr = max(0, self.stackptr-step)
+            self.stackptr = max(0, self.stackptr-self.step)
             self.stack_view.set_text(self.getStack())
 
         # DOWN stack
         if key in ('c','C'):
-            self.stackptr = self.stackptr+step
+            self.stackptr = self.stackptr+self.step
             self.stack_view.set_text(self.getStack())
 
         # UP source
         if key in ('f','F'):
-            self.srcptr = max(0, self.srcptr-step)
+            self.srcptr = max(0, self.srcptr-self.step)
             self.source_view.set_text(self.getSource(track=False))
 
         # DOWN source
         if key in ('v','V'):
-            self.srcptr = self.srcptr+step
+            self.srcptr = self.srcptr+self.step
             self.source_view.set_text(self.getSource(track=False))
 
         if key in ('t', 'T'):
@@ -698,7 +723,7 @@ def main(args):
             ops = loadWeirdJson(fname)
 
 
-    contexts = None
+    contract_stack = []
     if args.json:
         if not args.hash:
             parser.error('hash is required if contract json is provided')
@@ -714,7 +739,7 @@ def main(args):
                 c = Contract(sourceList, val)
                 contracts.append(c)
 
-        contexts = buildContexts(ops, api, contracts, args.hash)
+        contract_stack = buildContexts(ops, api, contracts, args.hash)
 
     if vm:
         print("\nTo view the generated trace:\n")
@@ -723,7 +748,7 @@ def main(args):
             cmd += " --web3 %s -s %s -j %s --hash %s" % (args.web3, args.source, args.json, args.hash)
         print(cmd)
 
-    DebugViewer().setTrace(ops, contexts)
+    DebugViewer().setTrace(ops, contract_stack)
 
 if __name__ == '__main__':
     options = parser.parse_args()


### PR DESCRIPTION
improves upon the initial source view implementation...

fixes a bug where the same contract is displayed for a given depth. The previous code assumed that depth to contract was a 1-1 mapping. This is not correct. In the scenario where A calls B, returns, then calls C, both B & C are at depth 1 but are different contracts.

fixes a bug with multi-contract files. The previous code assumed the contract we want to display was always the first in the file. We now use a regex and a loop to pull the currently executing contract out of the file

improves visibility of currently executing code. The current code is now highlighted in monochrome bold instead of being surrounded by `**`, improving readability