### PR TITLE
Experimental containers

### DIFF
--- a/containers/std-parity/Dockerfile
+++ b/containers/std-parity/Dockerfile
@@ -8,7 +8,8 @@ RUN \
   binutils pkg-config openssl libssl-dev libudev-dev
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH /root/.cargo/bin:$PATH
-RUN git clone --depth 1 --branch evmlab-trace https://github.com/cdetrio/parity
+RUN  git clone --depth 1 https://github.com/paritytech/parity
+#RUN git clone --depth 1 --branch evmlab-trace https://github.com/cdetrio/parity
 RUN cd parity && cargo build --release -p evmbin
 RUN cd parity && echo "{}"                                       \
   | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \

--- a/containers/std-parity/Dockerfile
+++ b/containers/std-parity/Dockerfile
@@ -1,5 +1,5 @@
 # Docker container spec for building a parity branch for standardized vm traces
-FROM ubuntu:16.04
+FROM ubuntu:16.04 as builder
 
 # Build parity on the fly and delete all build tools afterwards
 RUN \
@@ -20,6 +20,11 @@ RUN cd parity && echo "{}"                                       \
   apt-get remove -y curl git make g++ gcc file binutils pkg-config openssl libssl-dev && \
   rm -rf /root/.cargo
 
+
+from ubuntu:16.04
+RUN apt-get -y update && apt-get install -y libssl-dev libudev-dev
+COPY --from=builder /parity-evm /parity-evm
+COPY --from=builder /version.json /version.json
 ADD . /
-ENTRYPOINT ["/parity-evm"]
+#ENTRYPOINT ["/parity-evm"]
 RUN cat version.json

--- a/containers/testeth/Dockerfile
+++ b/containers/testeth/Dockerfile
@@ -1,24 +1,27 @@
-#Download base image ubuntu 14.04
-FROM ubuntu:14.04
+# Build stage 
+FROM alpine:latest as builder
+RUN apk add --no-cache \
+        git \
+        cmake \
+        g++ \
+        make \
+        linux-headers \
+        leveldb-dev --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+RUN git clone --recursive https://github.com/ethereum/testeth --branch develop --single-branch --depth 1
+RUN mkdir /build
+# See https://github.com/ethereum/cpp-ethereum/issues/4834
+RUN cd /build && cmake /testeth -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=OFF
+#RUN cd /build && cmake /testeth -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=OFF -DEVM_OPTIMIZE=0 -DSTATIC_LINKING=1
+RUN cmake --version
+RUN cd /build && make -j1 && make install; exit 0
+RUN cd /build && cp -r deps/lib64/libbinaryen.a deps/lib/; cp -r deps/lib64/libmpir.a deps/lib/
+RUN cd /build && make -j1 && make install
 
-# Update Ubuntu Software repository
-RUN     apt-get update \
-    &&  apt-get install git -y \
-    &&  cd /home && git clone --depth 1 --recursive https://github.com/ethereum/cpp-ethereum.git \
-    &&  sed -i '1s/^/\#define EVM_OPTIMIZE false\n/' cpp-ethereum/libevm/VMConfig.h \ 
-    &&  git clone --depth 1 --recursive https://github.com/winsvega/solidity.git \
-    &&  apt-get install curl libboost-all-dev libleveldb-dev libcurl4-openssl-dev libmicrohttpd-dev libminiupnpc-dev libgmp-dev -y \
-    &&  cd cpp-ethereum && ./scripts/install_cmake.sh --prefix /usr/local \
-    &&  ./scripts/install_deps.sh \
-    &&  mkdir build && cd build && cmake .. -DSTATIC_LINKING=1 && make \
-    &&  cp ./test/testeth ../../testeth \
-    &&  cd /home/solidity \
-    &&  ./scripts/install_deps.sh \
-    &&  mkdir build && cd build && cmake .. -DSTATIC_LINKING=1 && make \
-    &&  cp ./lllc/lllc /bin/lllc \
-    &&  cd /home && rm -r /home/cpp-ethereum && rm -r /home/solidity \
-    &&  apt-get remove curl libboost-all-dev libcurl4-openssl-dev libmicrohttpd-dev libminiupnpc-dev libgmp-dev -y \
-    &&  apt-get autoremove -y \
-    &&  apt purge
+# Install stage 
+FROM alpine:latest
+RUN apk add --no-cache \
+        libstdc++ \
+        leveldb --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+COPY --from=builder /build/test/testeth /usr/bin/testeth
 
-ENTRYPOINT ["/home/testeth"]
+#ENTRYPOINT ["/usr/bin/testeth"]

--- a/containers/testeth/Dockerfile
+++ b/containers/testeth/Dockerfile
@@ -8,15 +8,15 @@ RUN apk add --no-cache \
         linux-headers \
         leveldb-dev --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
 RUN git clone --recursive https://github.com/ethereum/testeth --branch develop --single-branch --depth 1
+RUN sed -i '1s/^/\#define EVM_OPTIMIZE false\n/' testeth/libevm/VMConfig.h
 RUN mkdir /build
 # See https://github.com/ethereum/cpp-ethereum/issues/4834
-RUN cd /build && cmake /testeth -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=OFF
+RUN cd /build && cmake /testeth -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=OFF -DEVM_OPTIMIZE=0
 #RUN cd /build && cmake /testeth -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=OFF -DEVM_OPTIMIZE=0 -DSTATIC_LINKING=1
 RUN cmake --version
 RUN cd /build && make -j1 && make install; exit 0
 RUN cd /build && cp -r deps/lib64/libbinaryen.a deps/lib/; cp -r deps/lib64/libmpir.a deps/lib/
 RUN cd /build && make -j1 && make install
-
 # Install stage 
 FROM alpine:latest
 RUN apk add --no-cache \

--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -9,7 +9,9 @@ FNULL = open(os.devnull, 'w')
 
 valid_opcodes = opcodes.reverse_opcodes.keys()
 
-
+# The 'stateRoot' output is missing from some clients (parity). 
+# Enable this once they implement it
+INCLUDE_STATEROOT=False
 
 try:
     from ethereum.utils import parse_int_or_hex,decode_hex,remove_0x_head
@@ -137,7 +139,6 @@ def compare_traces(clients_canon_traces, names):
             log('[*] {:>8} {}'.format("", step[0]))
         else:
             equivalent = False
-            
             for i in range(0, num_clients):
                 if i in wrong_clients or len(wrong_clients) == num_clients-1:
                     log('[!!] {:>7} {}'.format(names[i], step[i]))
@@ -217,14 +218,14 @@ class CppVM(VM):
                         x = x[:-1]
 
                     step = json.loads(x)
-                    if 'stateRoot' in step.keys():
+                    if 'stateRoot' in step.keys() and INCLUDE_STATEROOT:
                         steps.append(step)
 
             except Exception as e:
                 logger.info('Exception parsing cpp json:')
                 logger.info(e)
                 logger.info('problematic line:')
-                logger.info(x)
+                logger.info(x[:500])
 
         canon_steps = []
 
@@ -250,6 +251,15 @@ class CppVM(VM):
                     'stack' : toHexQuantities(step['stack']),
                 }
                 canon_steps.append(trace_step)
+
+                # Sometimes, the last one is duplicated. let's just remove that, if so
+
+                if len(canon_steps) > 1:
+                    last = canon_steps[-1]
+                    slast = canon_steps[-2]
+                    if slast['depth'] == last['depth'] and slast['pc'] == last['pc']:
+                        canon_steps = canon_steps[:-1]
+
         except Exception as e:
             logger.info('Exception parsing cpp step:')
             logger.info(e)
@@ -287,7 +297,7 @@ class PyVM(VM):
             #print (step)
             if 'stateRoot' in step.keys():
                 # dont log stateRoot when tx doesnt execute, to match cpp and parity
-                if len(canon_steps):
+                if len(canon_steps) and INCLUDE_STATEROOT:
                     canon_steps.append(step)
                 continue
             if 'event' not in step.keys():               
@@ -346,9 +356,6 @@ class GethVM(VM):
                     cmd.append('%s:%s' % (os.path.join('/private', genesis_mount.strip('/')), genesis_mount))
                 else:
                     cmd.append('%s:%s' % (genesis_mount, genesis_mount))
-#                kwargs['genesis'] = "mounted_genesis"
-#                cmd.append('%s:%s' % (get('genesis'),"/mounted_genesis"))
- #               kwargs['genesis'] = "mounted_genesis"
 
         cmd.append( self.executable ) 
 
@@ -412,7 +419,7 @@ class GethVM(VM):
                 if 'stateRoot' in step.keys() :
                     # don't log stateRoot when tx doesnt execute, to match cpp and parity
                     # should be last step
-                    if len(canon_steps):
+                    if len(canon_steps) and INCLUDE_STATEROOT:
                         canon_steps.append(step)
                     
                     continue
@@ -535,8 +542,8 @@ class ParityVM(VM):
                 if 'stateRoot' in p_step.keys():
                     # dont log the stateRoot for basic tx's (that have no EVM steps)
                     # should be last step
-                    if len(canon_steps):
-                        canon_steps.append(p_step)
+                    if len(canon_steps) and INCLUDE_STATEROOT:
+                        canon_steps.append(step)
                     continue
 
                 # Ignored for now

--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -137,7 +137,7 @@ def compare_traces(clients_canon_traces, names):
             log('[*] {:>8} {}'.format("", step[0]))
         else:
             equivalent = False
-            logger.info("")
+            
             for i in range(0, num_clients):
                 if i in wrong_clients or len(wrong_clients) == num_clients-1:
                     log('[!!] {:>7} {}'.format(names[i], step[i]))

--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -424,6 +424,13 @@ class GethVM(VM):
                     
                     continue
 
+
+                # Ignored for now
+                if 'error' in step.keys() and 'output' in step.keys():
+                    continue
+                if 'time' in step.keys():
+                    continue
+
                 if not 'op' in step.keys():
                     logger.warn("Missing 'op': %s" % str(step))
                     continue

--- a/statetests.ini
+++ b/statetests.ini
@@ -1,13 +1,15 @@
 [DEFAULT]
 
 fork_config = Byzantium
-clients = js,geth
+clients = geth
 
-tests_path = /ethereum/tests
+tests_path = /tmp/testfiles
 random_tests = No
 prestate_tmp_file = prestate.json
 single_test_tmp_file = single_test_tmp.json
 logs_path = randoLogs
+
+mode=docker_daemon
 
 py.docker_name     = cdetrio/pyethereum
 cpp.docker_name    = cdetrio/std-cpp-ethereum
@@ -19,8 +21,10 @@ js.docker_name = jwasinger/ethereumjs-vm
 
 [martin]
 
-geth.binary        = /home/martin/go/src/github.com/ethereum/go-ethereum/build/bin/evm
-
+geth.docker_name  = ethereum/client-go:alltools-latest
+cpp.docker_name   = ethereum/client-cpp
+testeth.docker_name   = holiman/testeth
+#testeth.docker_name = cdetrio/testeth
 
 [devops]
 

--- a/statetests.ini
+++ b/statetests.ini
@@ -1,7 +1,7 @@
 [DEFAULT]
 
 fork_config = Byzantium
-clients = geth,cpp
+clients = geth,cpp,parity
 
 tests_path = /tmp/testfiles
 random_tests = No

--- a/statetests.ini
+++ b/statetests.ini
@@ -1,7 +1,7 @@
 [DEFAULT]
 
 fork_config = Byzantium
-clients = geth
+clients = geth,parity
 
 tests_path = /tmp/testfiles
 random_tests = No
@@ -24,6 +24,7 @@ js.docker_name = jwasinger/ethereumjs-vm
 geth.docker_name  = ethereum/client-go:alltools-latest
 cpp.docker_name   = ethereum/client-cpp
 testeth.docker_name   = holiman/testeth
+parity.docker_name = holiman/parity
 #testeth.docker_name = cdetrio/testeth
 
 [devops]

--- a/statetests.ini
+++ b/statetests.ini
@@ -1,7 +1,7 @@
 [DEFAULT]
 
 fork_config = Byzantium
-clients = geth,parity
+clients = geth,cpp
 
 tests_path = /tmp/testfiles
 random_tests = No
@@ -22,7 +22,7 @@ js.docker_name = jwasinger/ethereumjs-vm
 [martin]
 
 geth.docker_name  = ethereum/client-go:alltools-latest
-cpp.docker_name   = ethereum/client-cpp
+cpp.docker_name   = holiman/testeth
 testeth.docker_name   = holiman/testeth
 parity.docker_name = holiman/parity
 #testeth.docker_name = cdetrio/testeth

--- a/trace_statetests_new.py
+++ b/trace_statetests_new.py
@@ -488,13 +488,6 @@ def finalizeTestEth(processInfo):
         if skip:
             continue
         outp += l
-
-#    outp = "\n".join(output_lines)
-    #print (outp)
-    #sys.exit(1)
-
-#    outp = [x for x in outp if not x.]
-
     #Validate that it's json
     try:
         test = json.loads(outp)

--- a/trace_statetests_new.py
+++ b/trace_statetests_new.py
@@ -493,10 +493,10 @@ def invokeTesteth():
         print('-'*60)
     return None
 
-def execInDocker(name, cmd):
+def execInDocker(name, cmd, stdout = True, stderr=True):
     print("executing in %s: %s" %  (name," ".join(cmd)))
     container = dockerclient.containers.get(name)
-    (exitcode, output) = container.exec_run(cmd, stream=True,stdout=False) 
+    (exitcode, output) = container.exec_run(cmd, stream=True,stdout=stdout, stderr = stderr) 
     return {'output': output, 'cmd':" ".join(cmd)}
 
 def startGeth(test):
@@ -509,7 +509,7 @@ def startGeth(test):
 
     """
     cmd = ["evm","--json","--nomemory","statetest","/testfiles/%s" % os.path.basename(test.tmpfile)]
-    return execInDocker("geth", cmd)
+    return execInDocker("geth", cmd, stdout = False)
     
 
 def startParity(test):
@@ -562,7 +562,7 @@ def end_processes(test):
 
             test.canon_traces.append(canon_trace)
 
-            logger.info("Processed %s steps for %s on test %s" % (len(canon_trace), client_name, test.name))
+            logger.info("Processed %s steps for %s on test %s (file %s) " % (len(canon_trace), client_name, test.name, full_trace_filename))
 
 
 def processTraces(test):

--- a/trace_statetests_new.py
+++ b/trace_statetests_new.py
@@ -352,9 +352,12 @@ def finishProc(name, processInfo, canonicalizer, fulltrace_filename = None):
     """ Ends the process, returns the canonical trace and also writes the 
     full process output to a file, along with the command used to start the process"""
 
+    outp = ""
+    for chunk in processInfo['output']:
+        outp = outp + chunk.decode()
 
-    outp = "".join([l.decode() for l in processInfo['output']])
     outp = outp.split("\n")
+
 
     if fulltrace_filename is not None:
         #logging.info("Writing %s full trace to %s" % (name, fulltrace_filename))
@@ -459,22 +462,28 @@ def invokeTesteth():
     """
     # docker exec -it suspicious_bassi /usr/bin/testeth -t GeneralStateTests -- --createRandomTest
     (name, isDocker) = getBaseCmd("testeth")
-    outputlines = []
-    if isDocker:    
-        container = dockerclient.containers.get('testeth')
-        (exitcode, output) = container.exec_run(['/usr/bin/testeth',"-t","GeneralStateTests","--","--createRandomTest"])  
-        output_lines = output.decode().strip().split("\n")
+    output_lines = []
+    if isDocker:
+        cmd = ['/usr/bin/testeth',"-t","GeneralStateTests","--","--createRandomTest"]
+        
+        processInfo = execInDocker('testeth', cmd, stderr=False)
+        outp = ""
+        for chunk in processInfo['output']:
+            outp = outp + chunk.decode()
+
+        output_lines = outp.split("\n")
+        #start_time = time.time()
+        #container = dockerclient.containers.get('testeth')
+        #(exitcode, output) = container.exec_run(cmd, stderr = False)  
+        #lapsed_time = time.time() - start_time
+        #logger.info("Generating test took %f seconds" % elapsed_time)
+        #output_lines = output.decode().strip().split("\n")
     else:
         cmd = [name]
 
         cmd.extend(["-t","GeneralStateTests","--","--createRandomTest"])
         output_lines = VMUtils.finishProc(VMUtils.startProc(cmd))
     
-    # A quirk in testeth... 
-    if output_lines[-1].find("*** No errors detected") > -1:
-        output_lines[-1] = ""
-    if output_lines[0].find("*** No errors detected") > -1:
-        output_lines[0] = ""
 
     outp = "".join(output_lines)
 
@@ -494,10 +503,14 @@ def invokeTesteth():
     return None
 
 def execInDocker(name, cmd, stdout = True, stderr=True):
-    print("executing in %s: %s" %  (name," ".join(cmd)))
+    start_time = time.time()
+    #logger.info("executing in %s: %s" %  (name," ".join(cmd)))
     container = dockerclient.containers.get(name)
-    (exitcode, output) = container.exec_run(cmd, stream=True,stdout=stdout, stderr = stderr) 
+    (exitcode, output) = container.exec_run(cmd, stream=True,stdout=stdout, stderr = stderr)     
+    logger.info("Executing %s : done in %f seconds" % (name, time.time() - start_time))
+
     return {'output': output, 'cmd':" ".join(cmd)}
+
 
 def startGeth(test):
     """
@@ -516,22 +529,34 @@ def startParity(test):
     cmd = ["/parity-evm","state-test", "--json","/testfiles/%s" % os.path.basename(test.tmpfile)]
     return execInDocker("parity", cmd)
 
-def startPython(test):
+def startCpp(test):
+    
+    #docker exec -it cpp /usr/bin/testeth -t GeneralStateTests -- --singletest /testfiles/0001--randomStatetestmartin-Fri_09_42_57-7812-0-1-test.json randomStatetestmartin-Fri_09_42_57-7812-0   --jsontrace '{ "disableStorage" : false, "disableMemory" : false, "disableStack" : false, "fullStorage" : true }' 
+    #docker exec -it cpp /usr/bin/testeth -t GeneralStateTests -- --singletest /testfiles/0015--randomStatetestmartin-Fri_10_15_53-13070-3-3-test.json randomStatetestmartin-Fri_10_15_53-13070-3 --jsontrace '{"disableStack": false, "fullStorage": false, "disableStorage": false, "disableMemory": false}'
 
-    tx_encoded = json.dumps(test.tx)
-    tx_double_encoded = json.dumps(tx_encoded) # double encode to escape chars for command line
+    cmd = ["/usr/bin/testeth",
+            "-t","GeneralStateTests","--",
+            "--singletest", "/testfiles/%s" % os.path.basename(test.tmpfile), test.name,
+            "--jsontrace", "'%s'" % json.dumps({"disableStorage": True, "disableMemory": True, "disableStack": False, "fullStorage": False}) 
+            ]
+    return execInDocker("cpp", cmd, stderr=False)
 
-    prestate_path = os.path.abspath(test.prestate_tmpfile)
-    mount_flag = prestate_path + ":" + "/mounted_prestate"
-    cmd = ["docker", "run", "--rm", "-t", "-v", mount_flag, cfg['PYETH_DOCKER_NAME'], "run_statetest.py", "/mounted_prestate", tx_double_encoded]
-
-    return {'proc':VMUtils.startProc(cmd), 'cmd': " ".join(cmd), 'output' : 'stdout'}
-
+#def startPython(test):
+#
+#    tx_encoded = json.dumps(test.tx)
+#    tx_double_encoded = json.dumps(tx_encoded) # double encode to escape chars for command line
+#
+#    prestate_path = os.path.abspath(test.prestate_tmpfile)
+#    mount_flag = prestate_path + ":" + "/mounted_prestate"
+#    cmd = ["docker", "run", "--rm", "-t", "-v", mount_flag, cfg['PYETH_DOCKER_NAME'], "run_statetest.py", "/mounted_prestate", tx_double_encoded]
+#
+#    return {'proc':VMUtils.startProc(cmd), 'cmd': " ".join(cmd), 'output' : 'stdout'}
+#
 
 def start_processes(test):
     clients = cfg['DO_CLIENTS']
 
-    starters = {'geth': startGeth, 'py': startPython, 'parity': startParity}
+    starters = {'geth': startGeth, 'cpp': startCpp, 'parity': startParity}
 
     logger.info("Starting processes for %s on test %s" % ( clients, test.name))
     #Start the processes
@@ -580,7 +605,6 @@ def processTraces(test):
             os.remove(f)
     else:
         logger.warning("CONSENSUS BUG!!!")
-
         # save the state-test
         statetest_filename = "%s/%s-test.json" %(cfg['LOGS_PATH'], test.id())
         os.rename(test.tmpfile,statetest_filename)
@@ -598,6 +622,7 @@ def processTraces(test):
         with open(summary_log_filename, "w+") as f:
             logger.info("Summary trace: %s" , summary_log_filename)
             f.write("\n".join(trace_summary))
+        sys.exit(1)
 
     return equivalent
 

--- a/trace_statetests_new.py
+++ b/trace_statetests_new.py
@@ -199,7 +199,7 @@ class StateTest():
 
 
 def iterate_tests(path = '/GeneralStateTests/', ignore = []):
-    logging.info (cfg['TESTS_PATH'] + path)
+    logger.info (cfg['TESTS_PATH'] + path)
     for subdir, dirs, files in sorted(os.walk(cfg['TESTS_PATH'] + path)):
         for f in files:
             if f.endswith('json'):
@@ -463,8 +463,6 @@ def invokeTesteth():
     if isDocker:    
         container = dockerclient.containers.get('testeth')
         (exitcode, output) = container.exec_run(['/usr/bin/testeth',"-t","GeneralStateTests","--","--createRandomTest"])  
-        print("testeth output ")
-        print(output.decode())
         output_lines = output.decode().strip().split("\n")
     else:
         cmd = [name]
@@ -496,9 +494,9 @@ def invokeTesteth():
     return None
 
 def execInDocker(name, cmd):
-    print("executing in %s", name)
+    print("executing in %s: %s" %  (name," ".join(cmd)))
     container = dockerclient.containers.get(name)
-    (exitcode, output) = container.exec_run(cmd, stream=True) 
+    (exitcode, output) = container.exec_run(cmd, stream=True,stdout=False) 
     return {'output': output, 'cmd':" ".join(cmd)}
 
 def startGeth(test):
@@ -515,7 +513,7 @@ def startGeth(test):
     
 
 def startParity(test):
-    cmd = ["state-test", "--json","/testfiles/%s" % os.path.basename(test.tmpfile)]
+    cmd = ["/parity-evm","state-test", "--json","/testfiles/%s" % os.path.basename(test.tmpfile)]
     return execInDocker("parity", cmd)
 
 def startPython(test):
@@ -564,7 +562,7 @@ def end_processes(test):
 
             test.canon_traces.append(canon_trace)
 
-            logging.info("Processed %s steps for %s on test %s" % (len(canon_trace), client_name, test.name))
+            logger.info("Processed %s steps for %s on test %s" % (len(canon_trace), client_name, test.name))
 
 
 def processTraces(test):


### PR DESCRIPTION
This PR updates `trace_statetests_new.py` to operate on semi-persistent docker containers. 

- Each testcase runs as basically `docker exec -it <name> <args>` instead of spinning up a new container every time
- Instead of using `subprocess`, it's using `docker-py` to communicate with docker directly. This makes the thing more robust