### PR TITLE
Add the ability to run trace equivalence tests on existing state test suite

### DIFF
--- a/statetests.ini
+++ b/statetests.ini
@@ -4,7 +4,7 @@ fork_config = Byzantium
 clients = geth,cpp,parity
 
 tests_path = /tmp/testfiles
-random_tests = No
+random_tests = Yes
 prestate_tmp_file = prestate.json
 single_test_tmp_file = single_test_tmp.json
 logs_path = randoLogs

--- a/trace_statetests_new.py
+++ b/trace_statetests_new.py
@@ -315,7 +315,7 @@ START_I = 0
 
 def iterate_tests():
     test_generator = generateTests
-    if cfg['RANDOM_TESTS'] != 'Yes':
+    if cfg['RANDOM_TESTS'] == 'No':
       test_generator = getStateTests
 
     number = 0


### PR DESCRIPTION
Adds this capability to `trace_statetests_new.py`.  It appears there may have been some changes applied that broke this feature.  I wasn't able to get it working with the older script: `trace_state_tests.py`.