### PR TITLE
Memory inspection feature #35

### DIFF
--- a/opviewer.py
+++ b/opviewer.py
@@ -639,8 +639,8 @@ class DebugViewer():
 
     def getHelp(self):
         return """Key navigation
-        a: Trace up        s: Mem up     d: Stack up    f: Source up    t: track source on/off
-        z: Trace down      x: Mem down   c: Stack down  v: Source down      Use uppercase for large steps
+        a: Trace up        s: Mem up     d: Stack up    f: Source up    t: track source on/off    m: write data to snapshot file
+        z: Trace down      x: Mem down   c: Stack down  v: Source down  Use uppercase for large steps
     press `q` to quit
         """
 

--- a/opviewer.py
+++ b/opviewer.py
@@ -429,6 +429,7 @@ class DebugViewer():
 
         self.ops_view = None
         self.mem_view = None
+        self.memref_view = None
         self.stack_view = None
         self.trace_view = None
         self.source_view = None
@@ -441,6 +442,7 @@ class DebugViewer():
 
         ops_view   = urwid.Text(self.getOp())
         mem_view   = urwid.Text(self.getMem())
+        memref_view  = urwid.Text(self.getMemref())
         stack_view = urwid.Text(self.getStack())
         trace_view = urwid.Text(self.getTrace())
         source_view = urwid.Text(self.getSource())
@@ -460,6 +462,7 @@ class DebugViewer():
 
         self.ops_view = ops_view
         self.mem_view = mem_view
+        self.memref_view = memref_view
         self.stack_view = stack_view
         self.trace_view = trace_view
         self.source_view = source_view
@@ -473,6 +476,7 @@ class DebugViewer():
                                 ),
                             urwid.Pile([
                                 wrap(mem_view,"Memory"),
+                                wrap(memref_view, "Memory Reference by Opcode"),
                                 wrap(stack_view, "Stack"),
                                 wrap(source_view, "Source"),
                                 ])
@@ -532,6 +536,12 @@ class DebugViewer():
             prev_m = "0x%s" % "".join(prev_m)
         return hexdump(m[2:], start = self.memptr, prevsrc = prev_m[2:])
 
+    def getMemref(self):
+        m = self._op('memory',"0x")
+        if type(m) is list:
+            m = "0x%s" % "".join(m)
+        return m
+
     def getStack(self):
         st = self._op('stack',[])
         opcode = self._op('op',None)
@@ -577,11 +587,13 @@ class DebugViewer():
         z: Trace down      x: Mem down   c: Stack down  v: Source down      Use uppercase for large steps
     press `q` to quit
         """
+
     def _refresh(self):
         self.source_view.set_text(self.getSource()) # needs to occur before getOp to print correct addr
         self.ops_view.set_text(self.getOp())
         self.trace_view.set_text(self.getTrace())
         self.mem_view.set_text(self.getMem())
+        self.memref_view.set_text(self.getMemref())
         self.stack_view.set_text(self.getStack())
 
     def dbg(self,text):

--- a/opviewer.py
+++ b/opviewer.py
@@ -96,6 +96,7 @@ def getMemoryReference(opcode):
 def memRefResolve(mem, refs, st, msg, opname, oplimit):
         append = ""
         st = st[::-1]
+        mem = mem[2:]
         mrefs = [0, 0]
         mrefs[0] = int(st[refs[0]], 16)
         if (refs[1] == -1):
@@ -105,7 +106,13 @@ def memRefResolve(mem, refs, st, msg, opname, oplimit):
         if oplimit > 0 and mrefs[1] > oplimit:
             mrefs[1] = oplimit
             append = "..."
-        return msg + " " + opname + " memory ref:\n" + "0x" + "".join(mem[(mrefs[0]*2)+2:(mrefs[0]+mrefs[1])*2+2]) + append + "\n"
+        if mrefs[1] < 0 or mrefs[0] < 0 or mrefs[0] > len(mem)/2:
+            mrefs = [0, 0]
+            append = " - memory access beyond expansion"
+        if (mrefs[0] + mrefs[1]) > len(mem)/2:
+            mrefs[1] = len(mem/2) - mrefs[0]
+            append = " - attempted read beyond memory bound of %d bytes" % (mrefs[0] + mrefs[1] - len(mem/2))
+        return msg + " " + opname + " memory ref:\n" + "0x" + "".join(mem[(mrefs[0]*2):(mrefs[0]+mrefs[1])*2]) + append + "\n"
 
 def dumpArea(f, name, content):
         f.write(name + "\n\n")


### PR DESCRIPTION
Added memory inspection to fulfill #35 - currently it's selectable if you press "SHIFT" and drag the mouse around, and it has normal ternimal text-copy behaviour. urwid doesn't seem to support "smart selection". Perhaps could make it so that if the user presses "m" the current memory inspection window is saved to a file?

I've also added support for showing memory referenced by a PREVIOUS opcode, in case the opcode is e.g. CALLDATACOPY and the user wants to see the resulting effect of that opcode on the memory area.

Screenshots:

[current opcode view](https://i.imgur.com/ZSTC7sL.png)
[prev opcode view](https://i.imgur.com/apiVYVZ.png)