### PR TITLE
Use docker interactive and tty flag when running image

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ Invoke via e.g. `python opviewer.py -f example2.json`
 The easiest way to get it working is to use a docker image. 
 
 ```
-docker build . -t evmlab && docker run evmlab
+docker build . -t evmlab && docker run -it evmlab
 ```
 
 The docker image should also be available at hub.docker.com, as an automated build:
 
 ```
-docker pull holiman/evmlab && docker run holiman/evmlab
+docker pull holiman/evmlab && docker run -it holiman/evmlab
 ```
 
 


### PR DESCRIPTION
It would seem that the intent was to give the user a shell to execute the supplied examples or their own cases. I am by no means a docker expert but this seems to be the correct way to do so